### PR TITLE
repeat visual input for matching text input

### DIFF
--- a/src/modeling/modeling.py
+++ b/src/modeling/modeling.py
@@ -216,8 +216,10 @@ class ClipBertBaseModel(BertPreTrainedModel):
             visual_inputs)  # (B, Lv, d)
         visual_attention_mask = attention_mask.new_ones(
             visual_embedding_output.shape[:2])  # (B, Lv)
+        label_per_vis = text_embedding_output.shape[0] // visual_embedding_output.shape[0]
+        visual_embedding_output = torch.repeat_interleave(visual_embedding_output, label_per_vis, dim=0)
         attention_mask = torch.cat(
-            [attention_mask, visual_attention_mask], dim=-1)  # (B, lt+Lv, d)
+            [attention_mask, visual_attention_mask], dim=-1)  # (B, lt+Lv)
         embedding_output = torch.cat(
             [text_embedding_output, visual_embedding_output],
             dim=1)  # (B, Lt+Lv, d)


### PR DESCRIPTION
Hi @jayleicn . I find a shape mismatch issue when I ran [video_retrieval](https://github.com/jayleicn/ClipBERT/blob/main/src/tasks/run_video_retrieval.py). This is mainly because each visual input will sample a negative text when we set [itm_neg_size](https://github.com/jayleicn/ClipBERT/blob/main/src/configs/didemo_ret_base_resnet50.json#L52) > 1, see [dataset](https://github.com/jayleicn/ClipBERT/blob/main/src/datasets/dataset_video_retrieval.py#L108). Therefore, I repeated the visual inputs to match the text inputs with negative sampling.